### PR TITLE
Update tests, recognize FL3 version data files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,8 +1,38 @@
 {
   "name": "sav-reader",
   "version": "2.0.3",
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "requires": true,
+  "packages": {
+    "": {
+      "name": "sav-reader",
+      "version": "2.0.3",
+      "license": "ISC",
+      "devDependencies": {
+        "@types/node": "^17.0.0",
+        "typescript": "^4.5.4"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.0.tgz",
+      "integrity": "sha512-eMhwJXc931Ihh4tkU+Y7GiLzT/y/DBNpNtr4yU9O2w3SYBsr9NaOPhQlLKRmoWtI54uNwuo0IOUFQjVOTZYRvw==",
+      "dev": true
+    },
+    "node_modules/typescript": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
+      "integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    }
+  },
   "dependencies": {
     "@types/node": {
       "version": "17.0.0",

--- a/src/SavReader.ts
+++ b/src/SavReader.ts
@@ -30,8 +30,9 @@ export class SavReader{
     async open() {
         
         // check file type
-        if (await this.reader.readString(4) != "$FL2") {
-            throw new Error("Not a valid .sav file");
+        let check = await this.reader.readString(4)
+        if (check != "$FL2" && check != '$FL3') {
+            throw new Error("Not a valid .sav file:"+ check);
         }
 
         // load metadata (variable names, # of cases (if specified), variable labels, value labels, etc.)

--- a/src/test/example1.js
+++ b/src/test/example1.js
@@ -7,10 +7,15 @@ const cc = {
     BgBlack: "\x1b[40m", BgRed: "\x1b[41m", BgGreen: "\x1b[42m", BgYellow: "\x1b[43m", BgBlue: "\x1b[44m", BgMagenta: "\x1b[45m", BgCyan: "\x1b[46m", BgWhite:"\x1b[47m",
 }
 
-const filename = "./test-data/generic dataset 6.sav";
+const filename =  process.argv[2] //|| "./test-data/generic dataset 6.sav";
+if (!filename) {
+    console.error("Specify filename")
+    console.error("Usage: node dist/test/example1.js <filename>")
+    console.error("Example: npm run example1 \"./test-data/generic dataset 6.sav\"")
+}
 
 async function test1() {
-    
+
     const sav = new SavFileReader(filename);
 
     await sav.open();
@@ -29,7 +34,7 @@ async function test1() {
         typestr += cc.FgCyan + ']';
 
         console.log(`${namestr} ${typestr} ${cc.Reset}${x.label}` );
-        
+
         // find and print value labels for this var if any
         let valueLabels = sav.meta.getValueLabels(x.name)
         if (valueLabels){
@@ -49,6 +54,7 @@ async function test1() {
         row = await sav.readNextRow();
 
         if( row != null ){
+            //console.log(JSON.stringify(row))
             if( sav.rowIndex % 1000 == 0 ){
                 console.log(sav.rowIndex, row['uuid']);
             }
@@ -62,7 +68,7 @@ async function test1() {
 
     console.log(cc.FgMagenta + 'Frequencies:' + cc.Reset)
     console.log(q1_frequencies);
-    
+
 
 }
 

--- a/src/test/test-files.ts
+++ b/src/test/test-files.ts
@@ -1,9 +1,14 @@
+import * as fs from "fs";
 import { SavFileReader } from "..";
 import { SysVarType } from "../SysVar";
 import { cc, eq, computeDescriptives } from "./TestHelpers.js";
 
-const sampleFilesFolder: string = "C:\\Program Files\\IBM\\SPSS Statistics\\Samples\\English";
-
+let sampleFilesFolders = [
+    process.env.SAMPLE_FILES_FOLDER,
+    "C:\\Program Files\\IBM\\SPSS Statistics\\Samples\\English",
+    "/Applications/IBM SPSS Statistics/Resources/Samples/English/"
+]
+const sampleFilesFolder: string = sampleFilesFolders.find(path=>fs.existsSync(path))
 const tests = [
     {
         file: "accidents.sav",


### PR DESCRIPTION
Minor updates:

- First check  environment variable for location of test files directory (may vary by user, particularly Windows/Mac)
- Recognize `'$FL3'` in addition to `'$FL2'` when checking if it is a valid SAV file
- Show usage instructions if calling /dist/test/example1.js without arguments